### PR TITLE
updated ziggyMethods.py and ziggyOptions.py

### DIFF
--- a/src/ziggy/ziggyOptions.py
+++ b/src/ziggy/ziggyOptions.py
@@ -2,7 +2,12 @@
     command line options.
 """
 
-from . import (STDERR, RED, WHITE, RESET)
+from . import (
+        RED,
+        GREEN,
+        WHITE,
+        RESET
+        )
 from .ziggyMethods import ZiggyMethods
 
 def ziggy_options(count: int, /, *options) -> int:
@@ -15,17 +20,21 @@ def ziggy_options(count: int, /, *options) -> int:
         case 1:
             match options[0]:
                 case 'help': return Methods.ziggy_help()
+                case 'list': return Methods.ziggy_emitter(f"{RED}missing{RESET} '{GREEN}installed or supported{RESET}'\n")
                 case 'primary': return Methods.ziggy_primary()
                 case 'install': return Methods.ziggy_install()
                 case 'upgrade': return Methods.ziggy_upgrade()
                 case 'destroy': return Methods.ziggy_destroy()
                 case 'version': return Methods.ziggy_version()
-                case _: return Methods.ziggy_emitter(f"'{WHITE}{options[0]}{RESET}' {RED}is invalid{RESET}\n")
+                case _: return Methods.ziggy_emitter(f"'{WHITE}{options[0]}{RESET}' {RED}isn't a valid option{RESET}\n")
         case 2:
             match options[0]:
+                case 'help': return Methods.ziggy_emitter(f"{GREEN}help{RESET} {RED}doesn't need an input{RESET}\n")
                 case 'list': return Methods.ziggy_list(options[1])
                 case 'primary': return Methods.ziggy_primary(options[1])
                 case 'install': return Methods.ziggy_install(options[1])
+                case 'upgrade': return Methods.ziggy_emitter(f"{GREEN}upgrade{RESET} {RED}doesn't need an input{RESET}\n")
                 case 'destroy': return Methods.ziggy_destroy(options[1])
-                case _: return Methods.ziggy_emitter(f"'{WHITE}{options[0]}{RESET}' {RED}is invalid{RESET}\n")
+                case 'version': return Methods.ziggy_emitter(f"{GREEN}version{RESET} {RED}doesn't need an input{RESET}\n")
+                case _: return Methods.ziggy_emitter(f"'{WHITE}{options[0]}{RESET}' {RED}isn't a valid option{RESET}\n")
         case _: return Methods.ziggy_emitter(f"{RED}Too many options{RESET}\n")


### PR DESCRIPTION
- Fixed `ziggy update`
- Fixed `ziggy install`
- Fixed `ziggy primary` -> now sets the most recent master version as primary when the version 0.12.0 is supplied
- Fixed `ziggy destroy` -> if more than one dev version is installed and a dev version is primary it isn't deleted
- Refactored entire **ziggyMthods.py** file
closes #4 