### PR TITLE
[FIXED] Windows Execution

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -3,7 +3,7 @@
     of the appropriate modules, and invoking all
     of the appropriate functions, classes, and methods.
 """
-from ziggy import ARGV, EXIT
+from ziggy import STDERR, ARGV, EXIT
 from ziggy.ziggyOptions import ziggy_options
 from ziggy.ziggyConfirm import ziggy_confirm
 

--- a/src/ziggy/ziggyMethods.py
+++ b/src/ziggy/ziggyMethods.py
@@ -140,7 +140,7 @@ class ZiggyMethods:
                         case 'x86':
                             if f'-{cls.PLATFORM}-i386-' in target or f'-{cls.PLATFORM}-x86-' in target:
                                 cls.AVAILABLE.insert(0, target)
-                        case 'x86_64':
+                        case 'AMD64':
                             if f'-win64-' in target or f'-{cls.PLATFORM}-x86_64-' in target:
                                 cls.AVAILABLE.insert(0, target)
                         case 'aarch64':

--- a/src/ziggy/ziggyMethods.py
+++ b/src/ziggy/ziggyMethods.py
@@ -67,8 +67,8 @@ class ZiggyMethods:
             cls.SEP = "\\"
             cls.EXTENSION = '.zip'
             cls.DEV_NULL = '2 > nul'
-            cls.TAR_CMD = 'tar -xf'
-            cls.LINK_CMD = 'mklink'
+            cls.TAR_CMD = 'unzip'
+            cls.LINK_CMD = f'mklink'
             cls.UNLINK_CMD = 'del'
             cls.RM_CMD = 'rmdir'
             if not EXISTS(cls.ZIGGY_DIR):


### PR DESCRIPTION
closes #6 
- **FIXED** missing import `STDERR`
- **UPDATED** architecture from `x86_64` to `AMD64` for Windows platform